### PR TITLE
ENG-3036 Added Edit Page Endpoint

### DIFF
--- a/packages/app-management-service/src/api/page/page.router.ts
+++ b/packages/app-management-service/src/api/page/page.router.ts
@@ -26,7 +26,9 @@ router.post('/pages',
       return next(handleError(e));
     }
 
-    appManager.createPage(req.body.code);
+    if (result.type === 'nx') {
+      appManager.createPage(req.body.code);
+    }
 
     res.status(201).send({
       payload: result,

--- a/packages/app-management-service/src/api/page/page.router.ts
+++ b/packages/app-management-service/src/api/page/page.router.ts
@@ -2,12 +2,15 @@ import { Router, Request, Response, NextFunction } from 'express';
 import { keycloak } from '../../middleware/keycloak';
 import { validate } from '../../middleware/validator';
 import { appManager } from '../../manager/AppManager';
+import getPage from '@entando-webui/app-engine-client/src/core/pages/getPage';
 import createPage from '@entando-webui/app-engine-client/src/core/pages/createPage';
 import deletePage from '@entando-webui/app-engine-client/src/core/pages/deletePage';
+import updatePage from '@entando-webui/app-engine-client/src/core/pages/updatePage';
 import updatePageStatus from '@entando-webui/app-engine-client/src/core/pages/updatePageStatus';
 import CreatePageRequest from './request/CreatePageRequest';
 import { InternalServerError, RestError } from '../../middleware/error';
 import UpdatePageStatusRequest from './request/UpdatePageStatusRequest';
+import UpdatePageRequest from './request/UpdatePageRequest';
 
 export const router: Router = Router();
 
@@ -45,6 +48,34 @@ router.delete('/pages/:code',
     appManager.deletePage(req.params.code);
 
     res.status(200).send({
+      payload: result,
+    });
+  }
+);
+
+router.put('/pages/:code',
+  keycloak.protect(),
+  validate(UpdatePageRequest),
+  async (req: Request, res: Response, next: NextFunction) => {
+    let result, page;
+    try {
+      page = await getPage(req.params.code);
+      result = await updatePage(req.body);
+    } catch (e) {
+      console.log('Error updating Entando Core Page');
+      return next(handleError(e));
+    }
+
+    // If type was changed...
+    if (page.type !== result.type) {
+      if (result.type === 'nx') {
+        appManager.createPage(req.params.code);
+      } else {
+        appManager.deletePage(req.params.code);
+      }
+    }
+
+    res.status(201).send({
       payload: result,
     });
   }

--- a/packages/app-management-service/src/api/page/request/UpdatePageRequest.ts
+++ b/packages/app-management-service/src/api/page/request/UpdatePageRequest.ts
@@ -1,0 +1,5 @@
+import CreatePageRequest from './CreatePageRequest';
+ 
+class UpdatePageRequest extends CreatePageRequest { }
+ 
+export default UpdatePageRequest;

--- a/packages/app-management-service/src/manager/impl/BaseAppManager.ts
+++ b/packages/app-management-service/src/manager/impl/BaseAppManager.ts
@@ -17,6 +17,7 @@ export abstract class BaseAppManager {
     if (!fs.existsSync(folderpath)) {
       fs.mkdirSync(folderpath, { recursive: true });
     }
+    // Silently replaces file if already existed
     fs.writeFileSync(filepath, data);
   }
 

--- a/packages/app-management-service/tests/app/router/__mocks__/page.mock.ts
+++ b/packages/app-management-service/tests/app/router/__mocks__/page.mock.ts
@@ -13,7 +13,7 @@ export const CREATE_PAGE_REQUEST = {
   contentType: 'text/html',
 };
 
-export const CREATE_PAGE_RESPONSE = {
+export const CREATE_NX_PAGE_RESPONSE = {
   code: 'new_page',
   status: 'unpublished',
   type: 'nx',
@@ -42,14 +42,29 @@ export const CREATE_PAGE_RESPONSE = {
   token: null
 };
 
+export const CREATE_LEGACY_PAGE_RESPONSE = {
+  ...CREATE_NX_PAGE_RESPONSE,
+  type: 'legacy',
+};
+
 export const UPDATE_PAGE_REQUEST = {
   ...CREATE_PAGE_REQUEST,
   parentCode: 'service',
 };
 
 export const UPDATE_PAGE_RESPONSE = {
-  ...CREATE_PAGE_RESPONSE,
+  ...CREATE_NX_PAGE_RESPONSE,
   parentCode: UPDATE_PAGE_REQUEST.parentCode,
+};
+
+export const UPDATE_TO_LEGACY_PAGE_RESPONSE = {
+  ...UPDATE_PAGE_RESPONSE,
+  type: 'legacy',
+};
+
+export const UPDATE_TO_NX_PAGE_RESPONSE = {
+  ...UPDATE_PAGE_RESPONSE,
+  type: 'nx',
 };
 
 export const CREATE_VALIDATION_ERRORS = [

--- a/packages/app-management-service/tests/app/router/__mocks__/page.mock.ts
+++ b/packages/app-management-service/tests/app/router/__mocks__/page.mock.ts
@@ -16,6 +16,7 @@ export const CREATE_PAGE_REQUEST = {
 export const CREATE_PAGE_RESPONSE = {
   code: 'new_page',
   status: 'unpublished',
+  type: 'nx',
   onlineInstance: false,
   displayedInMenu: true,
   pageModel: 'home',
@@ -41,7 +42,18 @@ export const CREATE_PAGE_RESPONSE = {
   token: null
 };
 
+export const UPDATE_PAGE_REQUEST = {
+  ...CREATE_PAGE_REQUEST,
+  parentCode: 'service',
+};
+
+export const UPDATE_PAGE_RESPONSE = {
+  ...CREATE_PAGE_RESPONSE,
+  parentCode: UPDATE_PAGE_REQUEST.parentCode,
+};
+
 export const CREATE_VALIDATION_ERRORS = [
+  'code must be a string',
   'titles should not be null or undefined',
   'parentCode must be a string',
   'ownerGroup must be a string',
@@ -51,6 +63,8 @@ export const CREATE_VALIDATION_ERRORS = [
   'charset must be a string',
   'contentType must be a string'
 ];
+
+export const UPDATE_VALIDATION_ERRORS = CREATE_VALIDATION_ERRORS;
 
 export const UPDATE_STATUS_VALIDATION_ERRORS_INVALID_STATUS = [
   'status must be one of the following values: draft, published',


### PR DESCRIPTION
- Added support to Edit Pages through the `app-management-service` API
- Changed the create page behaviour to ignore when creating a `legacy` page
- Added integration tests to edit a page
- Added integration tests to create a legacy page
- Added integration tests to convert a `legacy` page to an `nx` page
- Added integration tests to convert an `nx` page to a `legacy` page