### PR TITLE
ENG-3040 Added Clone Page Endpoint

### DIFF
--- a/packages/app-engine-client/src/core/pages/clonePage.ts
+++ b/packages/app-engine-client/src/core/pages/clonePage.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import { getServerKeycloakToken } from '../../keycloak/getServerKeycloakToken';
+import { IClonePageRequest } from './requests';
+
+export const clonePage = async (code: string, request: IClonePageRequest) => {
+  const token = await getServerKeycloakToken();
+  console.log('Cloning Entando Core Page:', code);
+  const res = await axios.post(`${process.env.ENTANDO_CORE_API_URL}/api/pages/${code}/clone`,
+    request, { headers: { Authorization: `Bearer ${token}` } }
+  );
+      
+  return res.data.payload;
+};
+
+export default clonePage;

--- a/packages/app-engine-client/src/core/pages/index.ts
+++ b/packages/app-engine-client/src/core/pages/index.ts
@@ -1,0 +1,7 @@
+export { default as createPage } from './createPage';
+export { default as deletePage } from './deletePage';
+export { default as getPage } from './getPage';
+export { default as listPages } from './listPages';
+export { default as updatePage } from './updatePage';
+export { default as updatePageStatus } from './updatePageStatus';
+export { default as clonePage } from './clonePage';

--- a/packages/app-engine-client/src/core/pages/requests.ts
+++ b/packages/app-engine-client/src/core/pages/requests.ts
@@ -14,3 +14,9 @@ export interface ICreatePageRequest {
 export interface IUpdatePageStatusRequest {
   status: string
 }
+
+export interface IClonePageRequest {
+  newPageCode: string
+  parentCode: string
+  titles: Map<string, string>
+}

--- a/packages/app-management-service/.eslintrc
+++ b/packages/app-management-service/.eslintrc
@@ -24,6 +24,7 @@
         "linebreak-style": [ "error", "unix" ],
         "quotes": [ "error", "single" ],
         "semi": [ "error", "always" ],
-        "eol-last": 1
+        "eol-last": 1,
+        "max-len": ["warn", { "code": 120, "ignoreComments": true }]
     }
 }

--- a/packages/app-management-service/src/api/page/page.router.ts
+++ b/packages/app-management-service/src/api/page/page.router.ts
@@ -2,15 +2,20 @@ import { Router, Request, Response, NextFunction } from 'express';
 import { keycloak } from '../../middleware/keycloak';
 import { validate } from '../../middleware/validator';
 import { appManager } from '../../manager/AppManager';
-import getPage from '@entando-webui/app-engine-client/src/core/pages/getPage';
-import createPage from '@entando-webui/app-engine-client/src/core/pages/createPage';
-import deletePage from '@entando-webui/app-engine-client/src/core/pages/deletePage';
-import updatePage from '@entando-webui/app-engine-client/src/core/pages/updatePage';
-import updatePageStatus from '@entando-webui/app-engine-client/src/core/pages/updatePageStatus';
 import CreatePageRequest from './request/CreatePageRequest';
 import { InternalServerError, RestError } from '../../middleware/error';
 import UpdatePageStatusRequest from './request/UpdatePageStatusRequest';
 import UpdatePageRequest from './request/UpdatePageRequest';
+
+import {
+  getPage,
+  createPage,
+  deletePage,
+  updatePage,
+  updatePageStatus,
+  clonePage
+} from '@entando-webui/app-engine-client/src/core/pages';
+import ClonePageRequest from './request/ClonePageRequest';
 
 export const router: Router = Router();
 

--- a/packages/app-management-service/src/api/page/page.router.ts
+++ b/packages/app-management-service/src/api/page/page.router.ts
@@ -88,6 +88,26 @@ router.put('/pages/:code',
   }
 );
 
+router.post('/pages/:code/clone',
+  keycloak.protect(),
+  validate(ClonePageRequest),
+  async (req: Request, res: Response, next: NextFunction) => {
+    let result;
+    try {
+      result = await clonePage(req.params.code, req.body);
+    } catch (e) {
+      console.log('Error Cloning Entando Core Page');
+      return next(handleError(e));
+    }
+
+    appManager.clonePage(req.params.code, req.body.newPageCode);
+
+    res.status(201).send({
+      payload: result,
+    });
+  }
+);
+
 router.put('/pages/:code/status',
   keycloak.protect(),
   validate(UpdatePageStatusRequest),

--- a/packages/app-management-service/src/api/page/request/ClonePageRequest.ts
+++ b/packages/app-management-service/src/api/page/request/ClonePageRequest.ts
@@ -1,0 +1,15 @@
+import { IClonePageRequest } from '@entando-webui/app-engine-client/src/core/pages/requests';
+import { IsString, IsDefined } from 'class-validator';
+ 
+class ClonePageRequest implements IClonePageRequest {
+  @IsString()
+  public newPageCode: string;
+
+  @IsString()
+  public parentCode: string;
+
+  @IsDefined()
+  public titles: Map<string, string>;
+}
+ 
+export default ClonePageRequest;

--- a/packages/app-management-service/src/manager/AppManager.ts
+++ b/packages/app-management-service/src/manager/AppManager.ts
@@ -6,6 +6,7 @@ export interface AppManager {
   savePageFile(code: string, data: string): void;
   createPage(code: string): void;
   deletePage(code: string): void;
+  clonePage(code: string, newPageCode: string): void;
   updatePageStatus(code: string, status: 'draft' | 'published'): void;
 }
 

--- a/packages/app-management-service/src/manager/impl/BaseAppManager.ts
+++ b/packages/app-management-service/src/manager/impl/BaseAppManager.ts
@@ -28,6 +28,14 @@ export abstract class BaseAppManager {
     }
   }
 
+  clonePage(code: string, newPageCode: string): void {
+    const draftFilepath = `${this.pagesDevPath()}/${code}.page.tsx`;
+    const clonedFilepath = `${this.pagesDevPath()}/${newPageCode}.page.tsx`;
+    if(fs.existsSync(draftFilepath)) {
+      fs.copyFileSync(draftFilepath, clonedFilepath);
+    } //else fails silently...
+  }
+
   updatePageStatus(code: string, status: 'draft' | 'published'): void {
     const draftFilepath = `${this.pagesDevPath()}/${code}.page.tsx`;
     const publishedFilepath = `${this.pagesDevPath()}/${code}.published.page.tsx`;

--- a/packages/app-management-service/src/manager/impl/BaseAppManager.ts
+++ b/packages/app-management-service/src/manager/impl/BaseAppManager.ts
@@ -28,14 +28,6 @@ export abstract class BaseAppManager {
     }
   }
 
-  clonePage(code: string, newPageCode: string): void {
-    const draftFilepath = `${this.pagesDevPath()}/${code}.page.tsx`;
-    const clonedFilepath = `${this.pagesDevPath()}/${newPageCode}.page.tsx`;
-    if(fs.existsSync(draftFilepath)) {
-      fs.copyFileSync(draftFilepath, clonedFilepath);
-    } //else fails silently...
-  }
-
   updatePageStatus(code: string, status: 'draft' | 'published'): void {
     const draftFilepath = `${this.pagesDevPath()}/${code}.page.tsx`;
     const publishedFilepath = `${this.pagesDevPath()}/${code}.published.page.tsx`;
@@ -47,4 +39,5 @@ export abstract class BaseAppManager {
   }
   
   abstract createPage(code: string): void;
+  abstract clonePage(code: string, newPageCode: string): void;
 }

--- a/packages/app-management-service/src/manager/impl/nextjs/NextJsAppManager.ts
+++ b/packages/app-management-service/src/manager/impl/nextjs/NextJsAppManager.ts
@@ -14,4 +14,17 @@ export class NextJsAppManager extends BaseAppManager {
     
     this.savePageFile(code, template(data));
   }
+
+  clonePage(code: string, newPageCode: string): void {
+    const draftFilepath = `${this.pagesDevPath()}/${code}.page.tsx`;
+    const clonedFilepath = `${this.pagesDevPath()}/${newPageCode}.page.tsx`;
+    if(fs.existsSync(draftFilepath)) {
+      const contents = fs.readFileSync(draftFilepath, 'utf8');
+      const clonedContents = contents.replace(
+        /const pageCode = '[a-zA-Z_]+';/g,
+        `const pageCode = '${newPageCode}';`
+      );
+      fs.writeFileSync(clonedFilepath, clonedContents);
+    } //else fails silently...
+  }
 }

--- a/packages/app-management-service/tests/app/router/__mocks__/page.mock.ts
+++ b/packages/app-management-service/tests/app/router/__mocks__/page.mock.ts
@@ -67,6 +67,44 @@ export const UPDATE_TO_NX_PAGE_RESPONSE = {
   type: 'nx',
 };
 
+export const CLONE_PAGE_REQUEST = {
+  newPageCode: 'cloned_page',
+  titles: {
+    'en': 'Cloned Page',
+    'it': 'Pagina Clonata'
+  },
+  parentCode: 'new_page'
+};
+
+export const CLONE_PAGE_RESPONSE = {
+  code: 'cloned_page',
+  status: 'unpublished',
+  type: 'nx',
+  onlineInstance: false,
+  displayedInMenu: true,
+  pageModel: 'home',
+  charset: 'utf-8',
+  contentType: 'text/html',
+  parentCode: 'new_page',
+  seo: false,
+  titles: {
+    'en': 'Cloned Page',
+    'it': 'Pagina Clonata'
+  },
+  fullTitles: {
+    en: 'Home / Cloned Page',
+    it: 'Home / Pagina Clonata'
+  },
+  ownerGroup: 'administrators',
+  joinGroups: [],
+  children: [],
+  position: 8,
+  numWidget: 0,
+  lastModified: '2021-12-08 14:12:35',
+  fullPath: 'homepage/new_page/cloned_page',
+  token: null
+};
+
 export const CREATE_VALIDATION_ERRORS = [
   'code must be a string',
   'titles should not be null or undefined',
@@ -80,6 +118,11 @@ export const CREATE_VALIDATION_ERRORS = [
 ];
 
 export const UPDATE_VALIDATION_ERRORS = CREATE_VALIDATION_ERRORS;
+
+export const CLONE_VALIDATION_ERRORS = [
+  'parentCode must be a string',
+  'titles should not be null or undefined'
+];
 
 export const UPDATE_STATUS_VALIDATION_ERRORS_INVALID_STATUS = [
   'status must be one of the following values: draft, published',

--- a/packages/app-management-service/tests/app/router/__mocks__/page.mock.ts
+++ b/packages/app-management-service/tests/app/router/__mocks__/page.mock.ts
@@ -120,6 +120,7 @@ export const CREATE_VALIDATION_ERRORS = [
 export const UPDATE_VALIDATION_ERRORS = CREATE_VALIDATION_ERRORS;
 
 export const CLONE_VALIDATION_ERRORS = [
+  'newPageCode must be a string',
   'parentCode must be a string',
   'titles should not be null or undefined'
 ];

--- a/packages/app-management-service/tests/app/router/page.test.ts
+++ b/packages/app-management-service/tests/app/router/page.test.ts
@@ -402,7 +402,7 @@ describe('User can Clone a Page', () => {
   test('tests clone a page with invalid request', async () => {
     const response = await supertest(app).post(`/api/pages/${CREATE_PAGE_REQUEST.code}/clone`)
       .set({ 'Authorization': `Bearer ${global.token}` })
-      .send({ newPageCode: 'cloned_page' })
+      .send({ /* empty body */ })
       .expect(400);
 
     expect(response.body.message).toBe('Validation Error');


### PR DESCRIPTION
- Added support to Clone Pages through the `app-management-service` API
- Changed the create page behaviour to ignore when creating a legacy page
- Added max line length=120 eslint rule
- Cleaned up some ugly imports
- Added integration tests to clone a page